### PR TITLE
Add Eboard page, Network dropdown, dress code

### DIFF
--- a/FRONTEND_AGENT_CONTEXT.MD
+++ b/FRONTEND_AGENT_CONTEXT.MD
@@ -1,0 +1,225 @@
+========================
+FRONTEND AGENT CONTEXT
+========================
+
+Repo: website (React + TypeScript)
+
+ROLE:
+You are modifying the frontend UI only.
+Do NOT implement business logic in the frontend.
+Always rely on backend responses for correctness.
+
+Backend status:
+- `dress_code` is now supported by backend event create/edit/read flows.
+- backend network/member responses may now include `display_email`
+- backend e-board responses may now include `display_email`
+- backend still preserves `user_email`
+- frontend should prefer `display_email` when present, and fall back to `user_email`
+
+--------------------------------
+FEATURE 1: NETWORK DROPDOWN
+--------------------------------
+
+GOAL:
+Replace top-level nav items:
+- Members
+- Alumni
+
+WITH:
+Network ▼
+  - Members (/network)
+  - Alumni (/alumni)
+  - Eboard (/eboard-network)
+
+FILES:
+- src/components/nav/NavLink.ts
+- src/components/layout/Navbar.tsx
+
+CHANGES:
+
+1. Update nav type:
+
+type NavItem = {
+  name: string;
+  href?: string;
+  children?: { name: string; href: string }[];
+};
+
+2. Update getNavLinks() to use:
+
+{
+  name: "Network",
+  children: [
+    { name: "Members", href: "/network" },
+    { name: "Alumni", href: "/alumni" },
+    { name: "Eboard", href: "/eboard-network" }
+  ]
+}
+
+3. Navbar behavior:
+- If `item.children` exists, render a dropdown
+- Desktop: support hover and/or click
+- Mobile: render as a collapsible section
+- Preserve existing logged-out behavior unless current app logic already gates these links by auth
+
+--------------------------------
+FEATURE 2: EBOARD PAGE
+--------------------------------
+
+CREATE:
+- src/pages/network/EboardPage.tsx
+
+ROUTE:
+- Add route for `/eboard-network`
+
+FETCH:
+- GET `/eboard`
+
+IMPORTANT:
+- Use backend response as the source of truth
+- Do not hardcode role-email substitution logic in frontend
+
+DATA MAPPING:
+Map backend e-board entries into the same shape expected by the existing network list UI.
+
+Minimum mapping target:
+
+{
+  type: "member",
+  name: entry.name,
+  email: entry.display_email || entry.role_email || entry.email,
+  major: entry.major
+}
+
+If the existing shared list component expects additional fields, adapt the mapping to match that existing contract.
+
+REUSE:
+- Reuse existing network UI where possible
+- Prefer reusing `NetworkList.tsx`
+
+--------------------------------
+FEATURE 3: DRESS CODE FIELD
+--------------------------------
+
+FILES:
+- CreateEventModal.tsx
+- EditEventModal.tsx
+
+ADD STATE:
+const [dressCode, setDressCode] = useState("");
+
+ADD INPUT:
+<input
+  type="text"
+  placeholder="e.g., Business Professional"
+  value={dressCode}
+  onChange={(e) => setDressCode(e.target.value)}
+/>
+
+ADD TO PAYLOAD:
+dress_code: dressCode.trim()
+
+EDIT MODE:
+- Ensure existing event `dress_code` populates edit form state if available
+- Preserve current modal structure and styling patterns
+
+--------------------------------
+FEATURE 4: DISPLAY DRESS CODE
+--------------------------------
+
+IN EVENT UI:
+Render dress code only when present.
+
+Example:
+
+{event.dress_code && (
+  <p>Dress Code: {event.dress_code}</p>
+)}
+
+APPLY TO:
+- event cards
+- event detail views
+- any event modal/preview that already shows event metadata
+
+Keep placement visually consistent with existing event metadata.
+
+--------------------------------
+FEATURE 5: EMAIL SUBSTITUTION
+--------------------------------
+
+BACKEND WILL PROVIDE:
+- `display_email`
+
+USE:
+- `email: item.display_email || item.user_email`
+
+FILES:
+- NetworkPage.tsx
+- AlumniPage.tsx
+- NetworkList.tsx
+
+IMPORTANT:
+- Do NOT compute substitution logic in frontend
+- Do NOT infer e-board membership in frontend
+- Only display backend-provided data
+
+RULE:
+Whenever rendering an email for network/alumni/member directory style UIs, prefer:
+- `display_email`
+- then fallback to `user_email`
+
+--------------------------------
+IMPLEMENTATION NOTES
+--------------------------------
+
+Auth/visibility intent:
+- Logged in users should have access to:
+  - Members
+  - Alumni
+  - Eboard
+- Logged out behavior should remain consistent with the current app unless routing/nav auth logic explicitly requires adjustment to expose the new dropdown structure
+
+Component strategy:
+- Reuse existing list and page patterns where possible
+- Avoid duplicating network rendering logic
+- Keep routing and UI changes minimal and consistent with the current codebase
+
+Data contract reminders:
+- Backend owns correctness
+- Frontend only displays:
+  - `dress_code`
+  - `display_email`
+  - `/eboard` results
+- Do not add frontend-only transformations beyond adapting backend payloads into existing component props
+
+--------------------------------
+RULES
+--------------------------------
+
+- DO NOT hardcode eboard business logic
+- DO NOT compute email substitution
+- DO NOT replace `user_email`
+- ONLY display backend-provided data
+- Keep logic in frontend limited to presentation, routing, and local UI state
+- Reuse existing components whenever possible
+
+--------------------------------
+CHECKLIST
+--------------------------------
+
+[ ] Network dropdown works
+[ ] Members/Alumni moved under Network
+[ ] Eboard page created
+[ ] `/eboard-network` route added
+[ ] Eboard page reuses existing list UI
+[ ] Dress code input added to create event
+[ ] Dress code input added to edit event
+[ ] Dress code included in create payload
+[ ] Dress code included in edit payload
+[ ] Dress code displayed in event UI
+[ ] Email uses `display_email` when provided
+[ ] No frontend hardcoded eboard/email substitution logic added
+
+========================
+END FRONTEND CONTEXT
+========================

--- a/Frontend/src/App.tsx
+++ b/Frontend/src/App.tsx
@@ -14,6 +14,7 @@ import Admin from "./pages/admin/Admin";
 import MemberView from "./pages/member/MemberView";
 import NetworkingPage from "./pages/network/NetworkingPage";
 import AlumniPage from "./pages/network/AlumniPage";
+import EboardPage from "./pages/network/EboardPage";
 import SponsorsNetworkPage from "./pages/sponsors-network/SponsorsNetworkPage";
 import NotFound from "./pages/notfound/NotFound";
 import ViewEvent from "./pages/events/ViewEvent";
@@ -68,6 +69,7 @@ function App() {
                   <Route path="/member" element={<MemberView />} />
                   <Route path="/network" element={<NetworkingPage />} />
                   <Route path="/alumni" element={<AlumniPage />} />
+                  <Route path="/eboard-network" element={<EboardPage />} />
                   <Route path="/sponsors-network" element={<SponsorsNetworkPage />} />
                   <Route path="/events/:eventId" element={<ViewEvent />} />
                   <Route path="/resources" element={<ResourcesPage />} />

--- a/Frontend/src/components/admin/CreateEventModal.tsx
+++ b/Frontend/src/components/admin/CreateEventModal.tsx
@@ -44,6 +44,7 @@ const CreateEventModal = ({
   const [time, setTime] = useState("");
   const [hours, setHours] = useState("");
   const [hoursType, setHoursType] = useState("professional");
+  const [dressCode, setDressCode] = useState("");
   const [checkInWindow, setCheckInWindow] = useState(15);
   const [checkInRadius, setCheckInRadius] = useState(50);
   const [eventLimit, setEventLimit] = useState(100);
@@ -63,6 +64,7 @@ const CreateEventModal = ({
     time,
     hours,
     hoursType,
+    dressCode,
     checkInWindow,
     checkInRadius,
     eventLimit,
@@ -80,6 +82,7 @@ const CreateEventModal = ({
       time,
       hours,
       hoursType,
+      dressCode,
       checkInWindow,
       checkInRadius,
       eventLimit,
@@ -170,6 +173,7 @@ const CreateEventModal = ({
         event_time: time,
         event_hours: parsedHours, // Send parsed number
         event_hours_type: hoursType,
+        dress_code: dressCode.trim(),
         sponsors_attending: sponsors,
         check_in_window: checkInWindow,
         check_in_radius: checkInRadius,
@@ -394,6 +398,23 @@ const CreateEventModal = ({
                 </p>
               )}
             </div>
+          </div>
+
+          <div className="mb-4">
+            <label
+              htmlFor="dressCode"
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
+              Dress Code
+            </label>
+            <input
+              id="dressCode"
+              type="text"
+              placeholder="e.g., Business Professional"
+              value={dressCode}
+              onChange={(e) => setDressCode(e.target.value)}
+              className="w-full border border-gray-300 rounded-lg p-2 focus:outline-none focus:ring-2 focus:ring-bapred"
+            />
           </div>
 
           {/* Hours & Type */}

--- a/Frontend/src/components/admin/EditEventModal.tsx
+++ b/Frontend/src/components/admin/EditEventModal.tsx
@@ -40,6 +40,7 @@ interface FormDataState {
   sponsors: string[];
   date: string;
   time: string;
+  dressCode: string;
   hours: string;
   hoursType: string;
   checkInWindow: number;
@@ -67,6 +68,7 @@ const EditEventModal = ({
     sponsors: [],
     date: "",
     time: "",
+    dressCode: "",
     hours: "",
     hoursType: "professional", // Default value
     checkInWindow: 15,
@@ -99,6 +101,7 @@ const EditEventModal = ({
       sponsors: eventToEdit.sponsors_attending || [],
       date: eventToEdit.event_date ? eventToEdit.event_date.split("T")[0] : "",
       time: eventToEdit.event_time || "",
+      dressCode: eventToEdit.dress_code || "",
       hours: eventToEdit.event_hours?.toString() || "",
       hoursType: eventToEdit.event_hours_type || "professional",
       checkInWindow: eventToEdit.check_in_window || 15,
@@ -204,7 +207,7 @@ const EditEventModal = ({
       const token = session.access_token;
 
       // --- Prepare data for EDIT endpoint ---
-      const eventDataToUpdate: { [key: string]: any } = {
+      const eventDataToUpdate: Record<string, unknown> = {
         event_id: eventToEdit.id,
         name: formData.eventTitle.trim(),
         date: formData.date || "",
@@ -215,6 +218,7 @@ const EditEventModal = ({
         },
         description: formData.description.trim(),
         time: formData.time || "",
+        dress_code: formData.dressCode.trim(),
         sponsors: formData.sponsors,
         check_in_window: formData.checkInWindow,
         check_in_radius: formData.checkInRadius,
@@ -254,6 +258,7 @@ const EditEventModal = ({
         event_long: formData.location.longitude,
         event_date: formData.date,
         event_time: formData.time,
+        dress_code: formData.dressCode.trim(),
         event_hours: parseFloat(formData.hours),
         event_hours_type: formData.hoursType,
         sponsors_attending: formData.sponsors,
@@ -365,6 +370,19 @@ const EditEventModal = ({
               <input id="time" name="time" type="time" placeholder="--:-- --" value={formData.time} onChange={handleInputChange} className={`w-full border rounded-lg p-2 focus:outline-none focus:ring-2 focus:ring-bapred ${errors.time ? 'border-red-500' : 'border-gray-300'}`} required aria-invalid={!!errors.time} aria-describedby={errors.time ? 'time-error' : undefined} />
               {errors.time && <p id="time-error" className="text-red-500 text-xs mt-1">{errors.time}</p>}
             </div>
+          </div>
+
+          <div className="mb-4">
+            <label htmlFor="dressCode" className="block text-sm font-medium text-gray-700 mb-1">Dress Code</label>
+            <input
+              id="dressCode"
+              name="dressCode"
+              type="text"
+              placeholder="e.g., Business Professional"
+              value={formData.dressCode}
+              onChange={handleInputChange}
+              className="w-full border border-gray-300 rounded-lg p-2 focus:outline-none focus:ring-2 focus:ring-bapred"
+            />
           </div>
 
           {/* ... Hours & Type ... */}

--- a/Frontend/src/components/event/EventCard.tsx
+++ b/Frontend/src/components/event/EventCard.tsx
@@ -382,6 +382,12 @@ export const EventCard: React.FC<EventCardProps> = ({
               </span>
             </div>
           )}
+          {event.dress_code && (
+            <div>
+              <span className="font-semibold text-gray-700">Dress Code: </span>
+              <span className="text-gray-600">{event.dress_code}</span>
+            </div>
+          )}
           {event.sponsors_attending && event.sponsors_attending.length > 0 && (
             <div>
               <span className="font-semibold text-gray-700">Sponsors: </span>

--- a/Frontend/src/components/event/EventListShort.tsx
+++ b/Frontend/src/components/event/EventListShort.tsx
@@ -53,6 +53,11 @@ export const EventListShort: React.FC<EventListShortProps> = ({ events, onEdit }
           <p className="text-sm text-gray-600 mb-2">
             <span className="font-semibold">RSVPs:</span> {event.rsvp_count || 0}
           </p>
+          {event.dress_code && (
+            <p className="text-sm text-gray-600 mb-2">
+              <span className="font-semibold">Dress Code:</span> {event.dress_code}
+            </p>
+          )}
           <div className="ml-auto flex gap-2 mt-1">
             <button
               className="px-3 py-1 border border-bapred text-bapred text-xs rounded-md hover:bg-red-50 transition-colors focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-bapred"

--- a/Frontend/src/components/layout/Navbar.tsx
+++ b/Frontend/src/components/layout/Navbar.tsx
@@ -3,9 +3,10 @@ import { Link } from "react-router-dom";
 import BAPLogo from "../../assets/BAP_Logo.png";
 import LogOut from "../logOut/LogOut";
 import type { RoleType } from "../../context/auth/authProvider";
+import type { NavItem } from "../nav/NavLink";
 
 interface NavbarProps {
-  links: { name: string; href: string; onClick?: () => void }[];
+  links: NavItem[];
   title: string;
   isLogged: boolean;
   backgroundColor?: string;
@@ -26,7 +27,11 @@ const Navbar: React.FC<NavbarProps> = ({
 
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isNavbarVisible, setIsNavbarVisible] = useState(true);
+  const [openDropdown, setOpenDropdown] = useState<string | null>(null);
+  const [openMobileSections, setOpenMobileSections] = useState<Record<string, boolean>>({});
   const menuRef = useRef<HTMLDivElement>(null);
+  const desktopNavRef = useRef<HTMLDivElement>(null);
+  const dropdownCloseTimeoutRef = useRef<number | null>(null);
   const lastScrollTop = useRef(0);
   const lastToggleTime = useRef(0);
 
@@ -40,7 +45,7 @@ const Navbar: React.FC<NavbarProps> = ({
     lastToggleTime.current = now;
 
     setIsMenuOpen((prev) => !prev);
-  }, [isMenuOpen]);
+  }, []);
 
   // Handle scroll events to hide/show navbar
   useEffect(() => {
@@ -66,6 +71,9 @@ const Navbar: React.FC<NavbarProps> = ({
       if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
         setIsMenuOpen(false);
       }
+      if (desktopNavRef.current && !desktopNavRef.current.contains(event.target as Node)) {
+        setOpenDropdown(null);
+      }
     };
 
     document.addEventListener("mousedown", handleClickOutside);
@@ -74,10 +82,19 @@ const Navbar: React.FC<NavbarProps> = ({
     };
   }, []);
 
+  useEffect(() => {
+    return () => {
+      if (dropdownCloseTimeoutRef.current) {
+        window.clearTimeout(dropdownCloseTimeoutRef.current);
+      }
+    };
+  }, []);
+
   // Handle menu item clicks to close the menu
   const handleMenuItemClick = useCallback((linkOnClick?: () => void) => {
     return () => {
       setIsMenuOpen(false);
+      setOpenDropdown(null);
       if (linkOnClick) {
         linkOnClick();
       }
@@ -100,7 +117,7 @@ const Navbar: React.FC<NavbarProps> = ({
   };
 
   // Add Resources link if logged in and not a sponsor
-  let navLinks = [...links];
+  const navLinks = [...links];
   const isSponsor =
     (typeof role === "string" && role === "sponsor") ||
     (typeof role === "object" && role !== null && "type" in role && role.type === "sponsor");
@@ -114,6 +131,32 @@ const Navbar: React.FC<NavbarProps> = ({
     const [resourcesLink] = navLinks.splice(resourcesIndex, 1);
     navLinks.unshift(resourcesLink);
   }
+
+  const toggleDesktopDropdown = (name: string) => {
+    setOpenDropdown((prev) => (prev === name ? null : name));
+  };
+
+  const openDesktopDropdown = (name: string) => {
+    if (dropdownCloseTimeoutRef.current) {
+      window.clearTimeout(dropdownCloseTimeoutRef.current);
+      dropdownCloseTimeoutRef.current = null;
+    }
+    setOpenDropdown(name);
+  };
+
+  const closeDesktopDropdown = (name: string) => {
+    dropdownCloseTimeoutRef.current = window.setTimeout(() => {
+      setOpenDropdown((prev) => (prev === name ? null : prev));
+      dropdownCloseTimeoutRef.current = null;
+    }, 180);
+  };
+
+  const toggleMobileSection = (name: string) => {
+    setOpenMobileSections((prev) => ({
+      ...prev,
+      [name]: !prev[name],
+    }));
+  };
 
   return (
     <nav className="fixed top-0 left-0 right-0 z-50 font-outfit">
@@ -154,17 +197,53 @@ const Navbar: React.FC<NavbarProps> = ({
           {/* Desktop Navigation - Change breakpoint to lg */}
           <div className="hidden lg:flex items-center space-x-6 z-10">
             {/* Main navigation links */}
-            <div className="flex space-x-6">
-              {navLinks.map((link) => (
-                <Link
-                  key={link.name}
-                  to={link.href}
-                  onClick={handleMenuItemClick(link.onClick)}
-                  className="hover:text-bapred text-xl font-medium"
-                >
-                  {link.name}
-                </Link>
-              ))}
+            <div ref={desktopNavRef} className="flex space-x-6">
+              {navLinks.map((link) =>
+                link.children?.length ? (
+                  <div
+                    key={link.name}
+                    className="relative"
+                    onMouseEnter={() => openDesktopDropdown(link.name)}
+                    onMouseLeave={() => closeDesktopDropdown(link.name)}
+                  >
+                    <button
+                      type="button"
+                      onClick={() => toggleDesktopDropdown(link.name)}
+                      className="hover:text-bapred text-xl font-medium flex items-center gap-1"
+                      aria-expanded={openDropdown === link.name}
+                    >
+                      <span>{link.name}</span>
+                      <span className="text-sm">▼</span>
+                    </button>
+                    {openDropdown === link.name && (
+                      <div className="absolute left-0 top-full pt-1">
+                        <div className="absolute left-0 -top-1 h-3 w-full" />
+                        <div className="min-w-[220px] rounded-md border border-gray-200 bg-white py-2 shadow-lg">
+                          {link.children.map((child) => (
+                            <Link
+                              key={child.name}
+                              to={child.href}
+                              onClick={handleMenuItemClick()}
+                              className="block px-4 py-3 text-base text-gray-700 hover:bg-gray-50 hover:text-bapred"
+                            >
+                              {child.name}
+                            </Link>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                ) : link.href ? (
+                  <Link
+                    key={link.name}
+                    to={link.href}
+                    onClick={handleMenuItemClick(link.onClick)}
+                    className="hover:text-bapred text-xl font-medium"
+                  >
+                    {link.name}
+                  </Link>
+                ) : null
+              )}
             </div>
 
             {/* Login/Logout always on the right */}
@@ -234,13 +313,43 @@ const Navbar: React.FC<NavbarProps> = ({
             {/* Navigation links */}
             {navLinks.map((link) => (
               <li key={link.name}>
-                <Link
-                  to={link.href}
-                  onClick={handleMenuItemClick(link.onClick)}
-                  className="hover:text-bapred text-xl font-medium"
-                >
-                  {link.name}
-                </Link>
+                {link.children?.length ? (
+                  <div className="flex flex-col items-center">
+                    <button
+                      type="button"
+                      onClick={() => toggleMobileSection(link.name)}
+                      className="hover:text-bapred text-xl font-medium flex items-center gap-2"
+                      aria-expanded={!!openMobileSections[link.name]}
+                    >
+                      <span>{link.name}</span>
+                      <span className="text-sm">
+                        {openMobileSections[link.name] ? "▲" : "▼"}
+                      </span>
+                    </button>
+                    {openMobileSections[link.name] && (
+                      <div className="mt-4 flex flex-col gap-4">
+                        {link.children.map((child) => (
+                          <Link
+                            key={child.name}
+                            to={child.href}
+                            onClick={handleMenuItemClick()}
+                            className="text-lg text-gray-700 hover:text-bapred"
+                          >
+                            {child.name}
+                          </Link>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                ) : link.href ? (
+                  <Link
+                    to={link.href}
+                    onClick={handleMenuItemClick(link.onClick)}
+                    className="hover:text-bapred text-xl font-medium"
+                  >
+                    {link.name}
+                  </Link>
+                ) : null}
               </li>
             ))}
 

--- a/Frontend/src/components/member/EventMember.tsx
+++ b/Frontend/src/components/member/EventMember.tsx
@@ -129,6 +129,7 @@ const EventMember: React.FC<EventMemberProps> = ({ eventAttendance = [], onRefre
                 event_location: attendedEvent.event_location,
                 event_date: attendedEvent.event_date || new Date().toISOString().split('T')[0],
                 event_time: attendedEvent.event_time,
+                dress_code: attendedEvent.dress_code,
                 event_hours: attendedEvent.event_hours,
                 event_hours_type: attendedEvent.event_hours_type,
                 rsvp_count: 0,

--- a/Frontend/src/components/nav/NavLink.ts
+++ b/Frontend/src/components/nav/NavLink.ts
@@ -1,4 +1,11 @@
-export const navLinks = [
+export type NavItem = {
+  name: string;
+  href?: string;
+  onClick?: () => void;
+  children?: { name: string; href: string }[];
+};
+
+export const navLinks: NavItem[] = [
   { name: "About Us", href: "/about" },
   { name: "Our Sponsors", href: "/sponsors" },
   { name: "Events", href: "/events" },
@@ -7,9 +14,15 @@ export const navLinks = [
   { name: "Log In", href: "/login" },
 ];
 
-const navLinksLoggedIn = [
-  { name: "Members", href: "/network" },
-  { name: "Alumni", href: "/alumni" },
+const navLinksLoggedIn: NavItem[] = [
+  {
+    name: "Network",
+    children: [
+      { name: "Members", href: "/network" },
+      { name: "Alumni", href: "/alumni" },
+      { name: "Eboard", href: "/eboard-network" },
+    ],
+  },
   { name: "Sponsors", href: "/sponsors-network" },
   { name: "Events", href: "/events" },
   { name: "Dashboard", href: "/admin" },

--- a/Frontend/src/components/network/NetworkProfileModal.tsx
+++ b/Frontend/src/components/network/NetworkProfileModal.tsx
@@ -48,8 +48,10 @@ const NetworkProfileModal: React.FC<NetworkProfileModalProps> = ({
           return;
         }
 
+        const memberLookupEmail = member.userEmail || member.email;
+
         const response = await fetch(
-          `${import.meta.env.VITE_BACKEND_URL}/member-info/${encodeURIComponent(member.email)}`,
+          `${import.meta.env.VITE_BACKEND_URL}/member-info/${encodeURIComponent(memberLookupEmail)}`,
           {
             headers: {
               "Content-Type": "application/json",

--- a/Frontend/src/components/network/NetworkingLayout.tsx
+++ b/Frontend/src/components/network/NetworkingLayout.tsx
@@ -1,10 +1,11 @@
 import Navbar from "../layout/Navbar";
 import Footer from "../layout/Footer";
 import { useAuth } from "../../context/auth/authProvider";
+import type { NavItem } from "../nav/NavLink";
 
 interface NetworkingLayoutProps {
   children: React.ReactNode;
-  navLinks: { name: string; href: string }[];
+  navLinks: NavItem[];
 }
 
 const NetworkingLayout = ({ children, navLinks }: NetworkingLayoutProps) => {

--- a/Frontend/src/pages/eboard-faculty/EboardFacultyPage.tsx
+++ b/Frontend/src/pages/eboard-faculty/EboardFacultyPage.tsx
@@ -57,7 +57,7 @@ const EboardFacultyPage: React.FC = () => {
         } else {
           setEboardEntries([]);
         }
-      } catch (err) {
+      } catch {
         setEboardEntries([]);
       }
     };
@@ -99,17 +99,17 @@ const EboardFacultyPage: React.FC = () => {
                     <h2 className="text-xl font-semibold">{entry.name || "-"}</h2>
                     <p className="text-bapred font-medium">{entry.role}</p>
                     <p className="text-sm text-bapgray">{entry.major || ""}</p>
-                    {entry.role_email && (
+                    {(entry.display_email || entry.role_email || entry.email) && (
                       <button
                         type="button"
                         className="text-bapred hover:underline focus:outline-none text-sm mt-2"
                         title="Copy role email to clipboard"
                         onClick={() => {
-                          navigator.clipboard.writeText(entry.role_email);
+                          navigator.clipboard.writeText(entry.display_email || entry.role_email || entry.email);
                           showToast("Role email copied to clipboard!", "success");
                         }}
                       >
-                        {entry.role_email}
+                        {entry.display_email || entry.role_email || entry.email}
                       </button>
                     )}
                   </div>

--- a/Frontend/src/pages/events/ViewEvent.tsx
+++ b/Frontend/src/pages/events/ViewEvent.tsx
@@ -109,6 +109,9 @@ const ViewEvent = () => {
               </div>
             </div>
             <p className="text-sm">Description: {event.event_description}</p>
+            {event.dress_code && (
+              <p className="text-sm">Dress Code: {event.dress_code}</p>
+            )}
             <p className="text-sm">Sponsors: {event.sponsors_attending?.join(", ") || "None"}</p>
             <p className="text-sm">Attendees: {event.attending_count}</p>
             <p className="text-sm">RSVPs: {event.rsvp_count}</p>

--- a/Frontend/src/pages/network/AlumniPage.tsx
+++ b/Frontend/src/pages/network/AlumniPage.tsx
@@ -21,6 +21,7 @@ interface BackendMember {
   id: number;
   user_id?: string;
   user_email?: string | null;
+  display_email?: string | null;
   development_hours?: number;
   professional_hours?: number;
   service_hours?: number;
@@ -183,7 +184,8 @@ const AlumniPage = () => {
             id: item.id.toString(),
             type: "member" as const,
             name: memberName,
-            email: item.user_email || "Not Provided",
+            email: item.display_email || item.user_email || "Not Provided",
+            userEmail: item.user_email || undefined,
             phone: "Not Provided", // Not in summary
             major: item.major || "Not Provided",
             graduationDate: item.graduating_year?.toString() || item.year || "Not Provided",

--- a/Frontend/src/pages/network/EboardPage.tsx
+++ b/Frontend/src/pages/network/EboardPage.tsx
@@ -1,0 +1,226 @@
+import { useEffect, useMemo, useState, useCallback } from "react";
+import Fuse from "fuse.js";
+import { useAuth } from "../../context/auth/authProvider";
+import type { EboardFacultyEntry, MemberDetail } from "../../types";
+import NetworkingLayout from "../../components/network/NetworkingLayout";
+import NetworkSearch from "../../components/network/NetworkSearch";
+import NetworkList from "../../components/network/NetworkList";
+import LoadingSpinner from "../../components/common/LoadingSpinner";
+import { getNavLinks } from "../../components/nav/NavLink";
+import { useSort, memberSortFields } from "../../utils/sortUtils";
+
+const eboardSortOptions = [
+  { value: "name-asc", label: "Name (A-Z)" },
+  { value: "name-desc", label: "Name (Z-A)" },
+  { value: "major-asc", label: "Major (A-Z)" },
+  { value: "major-desc", label: "Major (Z-A)" },
+  { value: "email-asc", label: "Email (A-Z)" },
+  { value: "email-desc", label: "Email (Z-A)" },
+];
+
+type BackendMemberSummary = {
+  id: number;
+  user_email?: string | null;
+  display_email?: string | null;
+  name?: string | null;
+  major?: string | null;
+  about?: string | null;
+  graduating_year?: string | null;
+  profile_photo_url?: string | null;
+  total_hours?: number | null;
+  rank?: string | null;
+  member_status?: string | null;
+  first_link?: string | null;
+  role?: string | null;
+};
+
+const formatRank = (rank?: string | null) => {
+  if (rank === "inducted") return "Inducted";
+  if (rank === "pledge") return "Pledge";
+  if (rank === "alumni") return "Alumni";
+  return "Inducted";
+};
+
+const mapEboardEntryToMember = (
+  entry: EboardFacultyEntry,
+  index: number,
+  memberSummary?: BackendMemberSummary
+): MemberDetail => ({
+  id: `eboard-${index}-${entry.role}`,
+  type: "member",
+  name: entry.name || memberSummary?.name || entry.role || "Unknown Member",
+  email: entry.display_email || entry.role_email || entry.email || "Not Provided",
+  userEmail: entry.email || undefined,
+  phone: "Not Provided",
+  major: memberSummary?.major || entry.major || "Not Provided",
+  graduationDate: memberSummary?.graduating_year?.toString() || "Not Provided",
+  status: memberSummary?.member_status || "Not Specified",
+  about: memberSummary?.about || entry.role || "No description provided.",
+  internship: "Not Specified",
+  photoUrl: entry.profile_photo_url || memberSummary?.profile_photo_url || "",
+  hours: memberSummary?.total_hours?.toString() ?? "0",
+  developmentHours: "0",
+  professionalHours: "0",
+  serviceHours: "0",
+  socialHours: "0",
+  links: memberSummary?.first_link ? [memberSummary.first_link] : [],
+  rank: formatRank(memberSummary?.rank),
+  role: memberSummary?.role || entry.role || "e-board",
+  event_attendance: [],
+});
+
+const EboardPage = () => {
+  const { session } = useAuth();
+  const [members, setMembers] = useState<MemberDetail[]>([]);
+  const [filteredMembers, setFilteredMembers] = useState<MemberDetail[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const { sortBy, sortedData: sortedMembers, handleSortChange } = useSort(
+    filteredMembers,
+    "name-asc",
+    memberSortFields
+  );
+
+  const fuse = useMemo(
+    () =>
+      new Fuse(members, {
+        includeScore: true,
+        threshold: 0.3,
+        keys: [
+          { name: "name", weight: 0.8 },
+          { name: "email", weight: 0.6 },
+          { name: "major", weight: 0.5 },
+          { name: "about", weight: 0.4 },
+        ],
+      }),
+    [members]
+  );
+
+  useEffect(() => {
+    const fetchEboard = async () => {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const token = session?.access_token;
+        if (!token) {
+          setError("You must be logged in to view this page");
+          return;
+        }
+
+        const headers = {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        };
+
+        const [eboardResponse, activeResponse, alumniResponse] = await Promise.all([
+          fetch(`${import.meta.env.VITE_BACKEND_URL}/eboard`, {
+            method: "GET",
+            headers,
+          }),
+          fetch(`${import.meta.env.VITE_BACKEND_URL}/member-info/active/summary`, {
+            method: "GET",
+            headers,
+          }),
+          fetch(`${import.meta.env.VITE_BACKEND_URL}/member-info/alumni/summary`, {
+            method: "GET",
+            headers,
+          }),
+        ]);
+
+        if (!eboardResponse.ok) {
+          throw new Error(`Error fetching e-board members: ${eboardResponse.statusText}`);
+        }
+
+        const eboardData: EboardFacultyEntry[] = await eboardResponse.json();
+        const activeMembers: BackendMemberSummary[] = activeResponse.ok ? await activeResponse.json() : [];
+        const alumniMembers: BackendMemberSummary[] = alumniResponse.ok ? await alumniResponse.json() : [];
+
+        const memberSummaryByEmail = new Map<string, BackendMemberSummary>();
+        [...activeMembers, ...alumniMembers].forEach((member) => {
+          if (member.user_email) {
+            memberSummaryByEmail.set(member.user_email, member);
+          }
+        });
+
+        setMembers(
+          eboardData.map((entry, index) =>
+            mapEboardEntryToMember(entry, index, entry.email ? memberSummaryByEmail.get(entry.email) : undefined)
+          )
+        );
+      } catch (fetchError) {
+        console.error("Error fetching e-board members:", fetchError);
+        setError("Failed to load e-board members. Please try again later.");
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchEboard();
+  }, [session]);
+
+  useEffect(() => {
+    if (!isLoading) {
+      setFilteredMembers(members);
+    }
+  }, [isLoading, members]);
+
+  const handleSearch = useCallback(
+    (query: string) => {
+      if (!query.trim()) {
+        setFilteredMembers(members);
+        return;
+      }
+
+      try {
+        const searchResults = fuse.search(query);
+        setFilteredMembers(searchResults.map((result) => result.item));
+      } catch (searchError) {
+        console.error("Error during e-board search:", searchError);
+        setFilteredMembers([]);
+      }
+    },
+    [fuse, members]
+  );
+
+  return (
+    <NetworkingLayout navLinks={getNavLinks(!!session)}>
+      <div className="max-w-7xl mx-auto px-4">
+        <h1 className="text-3xl sm:text-4xl md:text-5xl font-outfit font-bold text-bapred mb-6 text-center">
+          Our Eboard
+        </h1>
+
+        <NetworkSearch
+          onSearch={handleSearch}
+          availableGraduationYears={[]}
+          availableMajors={[]}
+          availableStatuses={[]}
+          sortOptions={eboardSortOptions}
+          sortValue={sortBy}
+          onSortChange={handleSortChange}
+        />
+
+        <div className="mt-6">
+          {isLoading ? (
+            <LoadingSpinner text="Loading e-board members..." />
+          ) : error ? (
+            <div className="bg-red-50 border border-red-200 text-red-800 rounded-md p-4">
+              <p>{error}</p>
+            </div>
+          ) : sortedMembers.length > 0 ? (
+            <NetworkList entities={sortedMembers} />
+          ) : (
+            members.length > 0 && (
+              <div className="bg-yellow-50 border border-yellow-200 text-yellow-800 rounded-md p-4">
+                <p>No e-board members found matching your search criteria.</p>
+              </div>
+            )
+          )}
+        </div>
+      </div>
+    </NetworkingLayout>
+  );
+};
+
+export default EboardPage;

--- a/Frontend/src/pages/network/NetworkingPage.tsx
+++ b/Frontend/src/pages/network/NetworkingPage.tsx
@@ -21,6 +21,7 @@ interface BackendMember {
   id: number;
   user_id?: string; // Keep if still used?
   user_email?: string | null;
+  display_email?: string | null;
   development_hours?: number;
   professional_hours?: number;
   service_hours?: number;
@@ -191,7 +192,8 @@ const NetworkingPage = () => {
             id: item.id.toString(),
             type: "member" as const,
             name: memberName,
-            email: item.user_email || "Not Provided",
+            email: item.display_email || item.user_email || "Not Provided",
+            userEmail: item.user_email || undefined,
             phone: "Not Provided", // Not in summary
             major: item.major || "Not Provided",
             graduationDate: item.graduating_year?.toString() || item.year || "Not Provided",

--- a/Frontend/src/types/index.ts
+++ b/Frontend/src/types/index.ts
@@ -1,6 +1,7 @@
 export interface MemberDetail {
   id: string;
   email: string;
+  userEmail?: string;
   name: string;
   phone: string;
   major: string;
@@ -49,6 +50,7 @@ export type BaseEvent = {
   event_location?: string;
   event_date: string;
   event_time?: string;
+  dress_code?: string;
   event_hours?: number;
   event_hours_type?: string;
   sponsors_attending?: string[];
@@ -119,6 +121,7 @@ export type EboardFacultyEntry = {
   role: string;
   role_email: string;
   email: string;
+  display_email?: string;
   profile_photo_url?: string;
   name: string | null;
   major: string | null;


### PR DESCRIPTION
Add Eboard page and route, introduce Network dropdown, and add dress code + display_email support.

- New EboardPage that fetches /eboard (and member summaries), maps backend e-board entries into MemberDetail, and reuses existing network UI; route /eboard-network registered in App.tsx.
- Replace top-level Members/Alumni links with a Network dropdown (NavItem type added). NavLink and Navbar updated to support nested children, desktop hover/click dropdowns, and mobile collapsible sections.
- Add dressCode state and input to CreateEventModal and EditEventModal; include dress_code in create/edit payloads. Display dress_code in EventCard, EventListShort, and ViewEvent; include dress_code when mapping event attendance in EventMember.
- Prefer backend-provided display_email where available (NetworkingPage, AlumniPage, EboardFacultyPage) and add userEmail to MemberDetail; NetworkProfileModal lookup updated to use userEmail when present.
- Update types (MemberDetail, BaseEvent, EboardFacultyEntry) to include userEmail, dress_code, and display_email.

All changes are presentation/UI-focused and rely on backend-provided fields (display_email, dress_code, /eboard) as the source of truth.